### PR TITLE
cmdparse.rb: fix a nil.sub bug

### DIFF
--- a/lib/cmdparse.rb
+++ b/lib/cmdparse.rb
@@ -625,7 +625,7 @@ module CmdParse
       content.split(/\n\n/).map do |paragraph|
         lines = []
         until paragraph.empty?
-          unless (str = paragraph.slice!(pattern).sub(/[ \n]\z/, ''))
+          unless (str = paragraph.slice!(pattern)) and (str = str.sub(/[ \n]\z/, ''))
             str = paragraph.slice!(0, line_length)
           end
           lines << (lines.empty? && !indent_first_line ? '' : ' ' * indent) + str.tr("\n", ' ')


### PR DESCRIPTION
When we have to format a word that is longer than the available space,
`paragraph.slice!(pattern)` will return nil. This case should be
detected by the `until` (and it is then correctly handed) but
unfortunately there is a `sub` call after the `slice!` which will error
out before. Fix this by only calling the `sub` if the result is not nil.

Note: my (trivial) patch uses a ruby 2.3 construction. This should be ok
since versions <2.3 are now eol.