### PR TITLE
Fix ruby-2.7 warning

### DIFF
--- a/lib/cmdparse.rb
+++ b/lib/cmdparse.rb
@@ -841,8 +841,8 @@ module CmdParse
     # Adds a top level command.
     #
     # See Command#add_command for detailed invocation information.
-    def add_command(*args, &block)
-      @main_command.add_command(*args, &block)
+    def add_command(*args, **kws, &block)
+      @main_command.add_command(*args, **kws, &block)
     end
 
     # Parses the command line arguments.


### PR DESCRIPTION
Fix the following warning:
cmdparse-3.0.4/lib/cmdparse.rb:845: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
cmdparse-3.0.4/lib/cmdparse.rb:305: warning: The called method `add_command' is defined here