### PR TITLE
Add MultiList#get_candidates

### DIFF
--- a/lib/cmdparse.rb
+++ b/lib/cmdparse.rb
@@ -157,6 +157,10 @@ module CmdParse
       EOF
     end
 
+    def get_candidates(id, &b)
+      @list.reverse_each {|list| list.get_candidates(id, &b)}
+    end
+
   end
 
   # === Base class for commands


### PR DESCRIPTION
When OptParse cannot parse an option, it raises a ParseError.

Given such a ParseError e, CmdParse then calls e.message, which itself
calls additional which is self.method(:additional_message).
In OptParse.additional_message, visit(:get_candidates,typ) get called.

But when the option is a CmdParse::MultiList, get_candidates does
not exist, which gives an error.

Fix this by adding a MultiList#get_candidates, which simply pass the
block to each list.